### PR TITLE
Refactor ShuttleProtocol to binary, implement channel switching and safety

### DIFF
--- a/ShuttleProtocol.h
+++ b/ShuttleProtocol.h
@@ -1,11 +1,15 @@
 #pragma once
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
-// --- Transport Layer: Frame Definition ---
-#define PROTOCOL_SYNC_1    0xAA
-#define PROTOCOL_SYNC_2    0x55
-#define PROTOCOL_VER       1
+// --- Transport Layer Constants ---
+#define PROTOCOL_SYNC_1           0xAA
+#define PROTOCOL_SYNC_2           0x55
+#define PROTOCOL_VER              1
+
+#define TARGET_ID_DISPLAY         0x00  // Direct UART line, target ID doesn't matter
+#define TARGET_ID_BROADCAST       0xFF  // Global command to all shuttles listening (use carefully)
 
 #pragma pack(push, 1)
 
@@ -13,69 +17,62 @@ typedef struct {
     uint8_t  sync1;      // Always 0xAA
     uint8_t  sync2;      // Always 0x55
     uint16_t length;     // Length of Payload ONLY (excludes header and CRC)
-    uint8_t  targetID;   // 0x00 = Display (Direct), 0x01-0x20 = Specific Shuttle
+    uint8_t  targetID;   // 0x00 = Display, 0x01-0x20 = Specific Shuttle, 0xFF = Broadcast
     uint8_t  seq;        // Rolling sequence counter (0-255)
     uint8_t  msgID;      // Identifies the Payload struct
 } FrameHeader;
 
-// --- Message IDs ---
 enum MsgID : uint8_t {
-    MSG_HEARTBEAT      = 0x01, // High freq: Position, Speed, State
-    MSG_SENSORS        = 0x02, // Med freq: TOF, Encoders, Pallet sensors
-    MSG_STATS          = 0x03, // Low freq: Odometry, Cycles
-    MSG_REQ_HEARTBEAT  = 0x04, // Pult -> Shuttle: Request Telemetry
-    MSG_REQ_SENSORS    = 0x05, // Pult -> Shuttle: Request Sensors (Only on Sensor Page)
-    MSG_REQ_STATS      = 0x06, // Pult -> Shuttle: Request Stats (Only on Stats Page)
+    MSG_HEARTBEAT      = 0x01, // Pushed by Shuttle: Position, Speed, State
+    MSG_SENSORS        = 0x02, // Pushed by Shuttle: TOF, Encoders, Pallet sensors
+    MSG_STATS          = 0x03, // Pushed by Shuttle: Odometry, Cycles
+    MSG_REQ_HEARTBEAT  = 0x04, // Pult -> Shuttle: Request Telemetry (Active Focus Keep-Alive)
+    MSG_REQ_SENSORS    = 0x05, // Pult -> Shuttle: Request Sensors
+    MSG_REQ_STATS      = 0x06, // Pult -> Shuttle: Request Stats
     MSG_LOG            = 0x10, // Async: Human readable strings with levels
-    MSG_CONFIG_SET     = 0x20, // Display -> Shuttle: Set EEPROM param
-    MSG_CONFIG_GET     = 0x21, // Display -> Shuttle: Request param
-    MSG_CONFIG_REP     = 0x22, // Shuttle -> Display: Reply with param
-    MSG_COMMAND        = 0x30, // Display -> Shuttle: Action command
-    MSG_ACK            = 0x31  // Shuttle -> Display: Command acknowledgment
+    MSG_CONFIG_SET     = 0x20, // Display/Pult -> Shuttle: Set EEPROM param
+    MSG_CONFIG_GET     = 0x21, // Display/Pult -> Shuttle: Request param
+    MSG_CONFIG_REP     = 0x22, // Shuttle -> Display/Pult: Reply with param
+    MSG_COMMAND        = 0x30, // Display/Pult -> Shuttle: Action command
+    MSG_ACK            = 0x31  // Shuttle -> Display/Pult: Command acknowledgment
 };
 
-// --- Enums ---
 enum LogLevel : uint8_t {
     LOG_INFO = 0, LOG_WARN = 1, LOG_ERROR = 2, LOG_DEBUG = 3
 };
 
-// Mapped from Cntrl_V1_2_WS.ino get_Cmd() / run_Cmd() strings
 enum CmdType : uint8_t {
-    CMD_STOP            = 5,   // "dStop_"
-    CMD_STOP_MANUAL     = 55,  // "dStopM"
-    CMD_MOVE_RIGHT_MAN  = 1,   // "dRight"
-    CMD_MOVE_LEFT_MAN   = 2,   // "dLeft_"
-    CMD_LIFT_UP         = 3,   // "dUp___"
-    CMD_LIFT_DOWN       = 4,   // "dDown_"
-    CMD_LOAD            = 6,   // "dLoad_"
-    CMD_UNLOAD          = 7,   // "dUnld_"
-    CMD_MOVE_DIST_R     = 8,   // "dMr"
-    CMD_MOVE_DIST_F     = 9,   // "dMf"
-    CMD_CALIBRATE       = 10,  // "dClbr_"
-    CMD_DEMO            = 11,  // "dDemo_"
-    CMD_COUNT_PALLETS   = 12,  // "dGetQu"
-    CMD_SAVE_EEPROM     = 13,  // "dSaveC"
-    CMD_COMPACT_F       = 14,  // "dComFo"
-    CMD_COMPACT_R       = 15,  // "dComBa"
-    CMD_GET_CONFIG      = 16,  // "dSGet_" / "dSpGet"
-    //CMD_TEST_SENSORS    = 17,  // "dDataP"
-    //CMD_ERROR_REQ       = 19,  // "tError"
-    CMD_EVACUATE_ON     = 20,  // "dEvOn_"
-    //CMD_EVACUATE_OFF    = 28,  // "dEvOff"
-    CMD_LONG_LOAD       = 21,  // "dLLoad"
-    CMD_LONG_UNLOAD     = 22,  // "dLUnld"
-    CMD_LONG_UNLOAD_QTY = 23,  // "dQt"
-    CMD_RESET_ERROR     = 24,  // "dReset"
-    CMD_MANUAL_MODE     = 25,  // "dManua"
-    CMD_LOG_MODE        = 26,  // "dGetLg"
-    CMD_HOME            = 27,  // "dHome_"
-    CMD_PING            = 100, // "ngPing"
-    CMD_FIRMWARE_UPDATE = 200, // "Firmware"
-    CMD_SYSTEM_RESET    = 201, // "Reboot__"
-    CMD_SET_DATETIME    = 202  // "DT"
+    CMD_STOP            = 5,
+    CMD_STOP_MANUAL     = 55, 
+    CMD_MOVE_RIGHT_MAN  = 1, 
+    CMD_MOVE_LEFT_MAN   = 2, 
+    CMD_LIFT_UP         = 3, 
+    CMD_LIFT_DOWN       = 4, 
+    CMD_LOAD            = 6, 
+    CMD_UNLOAD          = 7, 
+    CMD_MOVE_DIST_R     = 8, 
+    CMD_MOVE_DIST_F     = 9, 
+    CMD_CALIBRATE       = 10,
+    CMD_DEMO            = 11,
+    CMD_COUNT_PALLETS   = 12,
+    CMD_SAVE_EEPROM     = 13,
+    CMD_COMPACT_F       = 14,
+    CMD_COMPACT_R       = 15,
+    CMD_GET_CONFIG      = 16,
+    CMD_EVACUATE_ON     = 20,
+    CMD_LONG_LOAD       = 21,
+    CMD_LONG_UNLOAD     = 22,
+    CMD_LONG_UNLOAD_QTY = 23,
+    CMD_RESET_ERROR     = 24,
+    CMD_MANUAL_MODE     = 25,
+    CMD_LOG_MODE        = 26,
+    CMD_HOME            = 27,
+    CMD_PING            = 100,
+    CMD_FIRMWARE_UPDATE = 200,
+    CMD_SYSTEM_RESET    = 201,
+    CMD_SET_DATETIME    = 202 
 };
 
-// Config Parameter IDs for MSG_CONFIG_SET / GET
 enum ConfigParamID : uint8_t {
     CFG_SHUTTLE_NUM     = 1,   // "dNN"
     CFG_INTER_PALLET    = 2,   // "dDm"
@@ -89,43 +86,31 @@ enum ConfigParamID : uint8_t {
     CFG_REVERSE_MODE    = 10   // "dRevOn" / "dReOff"
 };
 
-// --- Payloads ---
-
-// 0x01: Heartbeat (High Frequency - e.g., 10Hz)
+// --- 4. Payloads ---
 struct TelemetryPacket {
     uint32_t timestamp;        // millis()
-    uint16_t errorCode;        // Replaces 16-byte errorStatus array
+    uint16_t errorCode;
     uint8_t  shuttleStatus;    // Current status (0-27 mapping)
     uint16_t currentPosition;  // mm
     uint16_t speed;            // Current speed %
     uint8_t  batteryCharge;    // %
     float    batteryVoltage;   // Volts
-
-    // Bitmask for boolean states to save bandwidth
-    // Bit 0: lifterUp, Bit 1: motorStart, Bit 2: motorReverse,
-    // Bit 3: inverse, Bit 4: inChannel, Bit 5: fifoLifo
-    uint16_t stateFlags;
-    uint8_t shuttleNumber; // Shuttle number
-    uint8_t palleteCount;  // Runtime pallet count (reset per op)
+    uint16_t stateFlags;       // Bit 0: lifterUp, 1: motorStart, 2: reverse, 3: inv, 4: inChnl, 5: fifoLifo
+    uint8_t  shuttleNumber;    
+    uint8_t  palleteCount;     // Runtime pallet count
 };
 
-// 0x02: Sensors (Medium Frequency - e.g., 2Hz)
 struct SensorPacket {
-    uint16_t distanceF;        // distance[1]
-    uint16_t distanceR;        // distance[0]
-    uint16_t distancePltF;     // distance[3]
-    uint16_t distancePltR;     // distance[2]
+    uint16_t distanceF;        
+    uint16_t distanceR;        
+    uint16_t distancePltF;     
+    uint16_t distancePltR;     
     uint16_t angle;            // as5600.readAngle()
-    int16_t  lifterCurrent;    //
+    int16_t  lifterCurrent;    
     float    temperature;      // Chip temp
-
-    // Bitmask for discrete hardware sensors
-    // Bit 0: detectPalleteF1, Bit 1: F2, Bit 2: R1, Bit 3: R2
-    // Bit 4: BUMPER_F, Bit 5: BUMPER_R, Bit 6: DL_UP, Bit 7: DL_DOWN
-    uint8_t hardwareFlags;
+    uint8_t  hardwareFlags;    // Discrete sensors bitmask
 };
 
-// 0x03: Stats (Low Frequency - e.g., 0.1Hz or on change)
 struct StatsPacket {
     uint32_t totalDist;                // Odometer (mm)
     uint32_t loadCounter;              // Number of loads
@@ -142,26 +127,17 @@ struct StatsPacket {
     uint16_t lowBatteryEvents;         // Number of low battery events (Error 11)
 };
 
-// 0x10: Log (Asynchronous)
-struct LogPacket {
-    uint8_t level;             // LogLevel enum
-    // char text[];            // Implicit payload data. Length = FrameHeader.length - 1
-};
-
-// 0x20 & 0x21 & 0x22: Configuration Set/Get/Report
 struct ConfigPacket {
     uint8_t paramID;           // ConfigParamID enum
     int32_t value;             // Value to set / reported value
 };
 
-// 0x30: Command
 struct CommandPacket {
     uint8_t cmdType;           // CmdType enum
     int32_t arg1;              // Used for Distances (dMr, dMf), Qty (dQt)
     int32_t arg2;              // Unused currently, reserved for future (e.g., specific speed)
 };
 
-// 0x31: ACK
 struct AckPacket {
     uint8_t refSeq;            // Sequence number of the command being ACK'd
     uint8_t result;            // 0 = Success/Accepted, 1 = Error, 2 = Busy
@@ -169,9 +145,9 @@ struct AckPacket {
 
 #pragma pack(pop)
 
-class ShuttleProtocol {
+class ProtocolUtils {
 public:
-    static uint16_t calcCRC16(const uint8_t* data, uint16_t length) {
+    static inline uint16_t calcCRC16(const uint8_t* data, uint16_t length) {
         uint16_t crc = 0xFFFF;
         for (uint16_t i = 0; i < length; i++) {
             crc ^= (uint16_t)data[i] << 8;
@@ -181,6 +157,13 @@ public:
             }
         }
         return crc;
+    }
+
+    // Safely appends the CRC to the end of a prepared buffer in Little-Endian format
+    static inline void appendCRC(uint8_t* buffer, uint16_t lengthWithoutCRC) {
+        uint16_t crc = calcCRC16(buffer, lengthWithoutCRC);
+        buffer[lengthWithoutCRC]     = (uint8_t)(crc & 0xFF);         // LSB
+        buffer[lengthWithoutCRC + 1] = (uint8_t)((crc >> 8) & 0xFF);  // MSB
     }
 };
 
@@ -196,18 +179,17 @@ public:
 
     bool crcError;
 
-    void init() {
-        reset();
-    }
+    ProtocolParser() { reset(); }
 
-    void reset() {
+    inline void reset() {
         state = STATE_WAIT_SYNC1;
         rxIndex = 0;
         payloadLen = 0;
         crcError = false;
     }
 
-    FrameHeader* feed(uint8_t byte) {
+    // Feeds a byte. Returns pointer to FrameHeader ONLY if perfect CRC match.
+    inline FrameHeader* feed(uint8_t byte) {
         switch (state) {
             case STATE_WAIT_SYNC1:
                 crcError = false;
@@ -216,6 +198,7 @@ public:
                     state = STATE_WAIT_SYNC2;
                 }
                 break;
+                
             case STATE_WAIT_SYNC2:
                 if (byte == PROTOCOL_SYNC_2) {
                     rxBuffer[1] = byte;
@@ -225,11 +208,13 @@ public:
                     state = STATE_WAIT_SYNC1;
                 }
                 break;
+                
             case STATE_READ_HEADER:
                 rxBuffer[rxIndex++] = byte;
                 if (rxIndex >= sizeof(FrameHeader)) {
                     FrameHeader* header = (FrameHeader*)rxBuffer;
                     payloadLen = header->length;
+                    
                     if (payloadLen > sizeof(rxBuffer) - sizeof(FrameHeader) - 2) {
                         state = STATE_WAIT_SYNC1;
                         rxIndex = 0;
@@ -240,18 +225,21 @@ public:
                     }
                 }
                 break;
+                
             case STATE_READ_PAYLOAD:
                 rxBuffer[rxIndex++] = byte;
                 if (rxIndex >= sizeof(FrameHeader) + payloadLen) {
                     state = STATE_READ_CRC;
                 }
                 break;
+                
             case STATE_READ_CRC:
                 rxBuffer[rxIndex++] = byte;
                 if (rxIndex >= sizeof(FrameHeader) + payloadLen + 2) {
                     uint16_t totalLen = sizeof(FrameHeader) + payloadLen;
+                    
                     uint16_t receivedCRC = rxBuffer[totalLen] | (rxBuffer[totalLen+1] << 8);
-                    uint16_t calculatedCRC = ShuttleProtocol::calcCRC16(rxBuffer, totalLen);
+                    uint16_t calculatedCRC = ProtocolUtils::calcCRC16(rxBuffer, totalLen);
 
                     state = STATE_WAIT_SYNC1;
 
@@ -267,12 +255,9 @@ public:
         return nullptr;
     }
 
-    uint8_t* getBuffer() { return rxBuffer; }
-    uint16_t getTotalLength() { return sizeof(FrameHeader) + payloadLen; }
-
 private:
     State state;
-    uint8_t rxBuffer[512];
+    uint8_t rxBuffer[256];
     uint16_t rxIndex;
     uint16_t payloadLen;
 };


### PR DESCRIPTION
- Updated `ShuttleProtocol.h` with new binary frame format (Header, CRC, TargetID) and Message IDs.
- Implemented `ProtocolParser` for unified packet handling.
- Refactored `Cntrl_V1_2_WS.ino` to use `ProtocolParser` for both Serial1 (Radio) and Serial2 (Display).
- Replaced legacy string parsing (`get_Cmd`) with binary command mapping (`executeCommand`).
- Removed blind telemetry broadcasts; implemented reactive request handlers (`MSG_REQ_*`).
- Implemented `changeChannelAndReset` for dynamic RF channel switching via Ebyte module configuration.
- Added safety watchdog (2s timeout) and manual mode polling inside blocking loops.
- Implemented CRC16 validation in `pollIncomingPackets` to drop corrupted frames.
- Removed legacy `Serial2.print` commands.

---
*PR created automatically by Jules for task [8006757477578912781](https://jules.google.com/task/8006757477578912781) started by @Driadix*