### PR TITLE
Refactor Shuttle Protocol to Binary State Machine

### DIFF
--- a/ShuttleProtocol.h
+++ b/ShuttleProtocol.h
@@ -8,7 +8,7 @@
 #define PROTOCOL_SYNC_2           0x55
 #define PROTOCOL_VER              1
 
-#define TARGET_ID_ANY             0x00  // Direct UART line, target ID doesn't matter
+#define TARGET_ID_NONE        0x00  // Direct UART line, target ID doesn't matter
 #define TARGET_ID_BROADCAST       0xFF  // Global command to all shuttles listening (use carefully)
 
 #pragma pack(push, 1)
@@ -43,15 +43,15 @@ enum LogLevel : uint8_t {
 
 enum CmdType : uint8_t {
     CMD_STOP            = 5,
-    CMD_STOP_MANUAL     = 55, 
-    CMD_MOVE_RIGHT_MAN  = 1, 
-    CMD_MOVE_LEFT_MAN   = 2, 
-    CMD_LIFT_UP         = 3, 
-    CMD_LIFT_DOWN       = 4, 
-    CMD_LOAD            = 6, 
-    CMD_UNLOAD          = 7, 
-    CMD_MOVE_DIST_R     = 8, 
-    CMD_MOVE_DIST_F     = 9, 
+    CMD_STOP_MANUAL     = 55,
+    CMD_MOVE_RIGHT_MAN  = 1,
+    CMD_MOVE_LEFT_MAN   = 2,
+    CMD_LIFT_UP         = 3,
+    CMD_LIFT_DOWN       = 4,
+    CMD_LOAD            = 6,
+    CMD_UNLOAD          = 7,
+    CMD_MOVE_DIST_R     = 8,
+    CMD_MOVE_DIST_F     = 9,
     CMD_CALIBRATE       = 10,
     CMD_DEMO            = 11,
     CMD_COUNT_PALLETS   = 12,
@@ -70,7 +70,7 @@ enum CmdType : uint8_t {
     CMD_PING            = 100,
     CMD_FIRMWARE_UPDATE = 200,
     CMD_SYSTEM_RESET    = 201,
-    CMD_SET_DATETIME    = 202 
+    CMD_SET_DATETIME    = 202
 };
 
 enum ConfigParamID : uint8_t {
@@ -96,17 +96,17 @@ struct TelemetryPacket {
     uint8_t  batteryCharge;    // %
     float    batteryVoltage;   // Volts
     uint16_t stateFlags;       // Bit 0: lifterUp, 1: motorStart, 2: reverse, 3: inv, 4: inChnl, 5: fifoLifo
-    uint8_t  shuttleNumber;    
+    uint8_t  shuttleNumber;
     uint8_t  palleteCount;     // Runtime pallet count
 };
 
 struct SensorPacket {
-    uint16_t distanceF;        
-    uint16_t distanceR;        
-    uint16_t distancePltF;     
-    uint16_t distancePltR;     
+    uint16_t distanceF;
+    uint16_t distanceR;
+    uint16_t distancePltF;
+    uint16_t distancePltR;
     uint16_t angle;            // as5600.readAngle()
-    int16_t  lifterCurrent;    
+    int16_t  lifterCurrent;
     float    temperature;      // Chip temp
     uint8_t  hardwareFlags;    // Discrete sensors bitmask
 };
@@ -198,7 +198,7 @@ public:
                     state = STATE_WAIT_SYNC2;
                 }
                 break;
-                
+
             case STATE_WAIT_SYNC2:
                 if (byte == PROTOCOL_SYNC_2) {
                     rxBuffer[1] = byte;
@@ -208,13 +208,13 @@ public:
                     state = STATE_WAIT_SYNC1;
                 }
                 break;
-                
+
             case STATE_READ_HEADER:
                 rxBuffer[rxIndex++] = byte;
                 if (rxIndex >= sizeof(FrameHeader)) {
                     FrameHeader* header = (FrameHeader*)rxBuffer;
                     payloadLen = header->length;
-                    
+
                     if (payloadLen > sizeof(rxBuffer) - sizeof(FrameHeader) - 2) {
                         state = STATE_WAIT_SYNC1;
                         rxIndex = 0;
@@ -225,19 +225,19 @@ public:
                     }
                 }
                 break;
-                
+
             case STATE_READ_PAYLOAD:
                 rxBuffer[rxIndex++] = byte;
                 if (rxIndex >= sizeof(FrameHeader) + payloadLen) {
                     state = STATE_READ_CRC;
                 }
                 break;
-                
+
             case STATE_READ_CRC:
                 rxBuffer[rxIndex++] = byte;
                 if (rxIndex >= sizeof(FrameHeader) + payloadLen + 2) {
                     uint16_t totalLen = sizeof(FrameHeader) + payloadLen;
-                    
+
                     uint16_t receivedCRC = rxBuffer[totalLen] | (rxBuffer[totalLen+1] << 8);
                     uint16_t calculatedCRC = ProtocolUtils::calcCRC16(rxBuffer, totalLen);
 


### PR DESCRIPTION
This change modernizes the shuttle communication protocol by replacing ad-hoc parsing with a robust binary protocol state machine (`ProtocolParser`) derived from `ShuttleProtocol.h`.

Key changes:
1.  **Dual Protocol Parsers:** Instantiated `parserRadio` and `parserDisplay` to handle binary commands on both Serial1 and Serial2 independently.
2.  **Telemetry Routing:**
    *   Periodic telemetry (Heartbeat, Sensors, Stats) is now pushed to the Display (`Serial2`) via the main loop timers.
    *   Radio (`Serial1`) telemetry is now strictly reactive, responding only to `MSG_REQ_HEARTBEAT`, `MSG_REQ_SENSORS`, and `MSG_REQ_STATS` commands.
3.  **Command Handling:**
    *   Replaced `parseSerial1` and legacy text command parsing in `get_Cmd` with a unified `pollSerial` helper that feeds the binary parsers.
    *   `processPacket` now handles request messages and sends acknowledgments (`MSG_ACK`) to the originating port.
    *   `MSG_CONFIG_SET` and `MSG_CONFIG_GET` are supported in the binary protocol, replacing legacy text configuration commands.
4.  **CRC & Robustness:**
    *   Removed local `calcCRC16` function.
    *   Updated `SecureStats` (SRAM) and Flash configuration handling to use `ProtocolUtils::calcCRC16`.
    *   Send functions now safely append CRC using `ProtocolUtils::appendCRC`.
    *   Added null pointer checks for output streams.

This refactoring preserves core shuttle logic while enabling reliable binary communication on both interfaces.

---
*PR created automatically by Jules for task [7250567581742890765](https://jules.google.com/task/7250567581742890765) started by @Driadix*