### PR TITLE
Refactor Cntrl_V1_2_WS.ino to align with ShuttleProtocol V2

### DIFF
--- a/Cntrl_V1_2_WS.ino
+++ b/Cntrl_V1_2_WS.ino
@@ -343,10 +343,6 @@ void sendLog(LogLevel level, const char* msg, Stream* port = &Serial1) {
   uint8_t logBuffer[300]; // Ample room for header + MAX_LOG_STRING_LEN + CRC
   uint16_t msgLen = strlen(msg);
 
-void sendLog(LogLevel level, const char* msg, Stream* port = &Serial1) {
-  uint8_t logBuffer[300]; // Ample room for header + MAX_LOG_STRING_LEN + CRC
-  uint16_t msgLen = strlen(msg);
-
   // SECURE BOUNDS: Cap at 253 bytes to leave room for the null terminator
   // ensuring total payload never exceeds MAX_LOG_STRING_LEN
   if (msgLen > MAX_LOG_STRING_LEN - 1) {
@@ -368,7 +364,7 @@ void sendLog(LogLevel level, const char* msg, Stream* port = &Serial1) {
   // Safe memory copy, implicitly including the null terminator because
   // logBuffer is zeroed out or we explicitly terminate it
   memcpy(logBuffer + sizeof(FrameHeader) + 1, msg, msgLen);
-  logBuffer[sizeof(FrameHeader) + 1 + msgLen] = "\0"; // Force null termination
+  logBuffer[sizeof(FrameHeader) + 1 + msgLen] = '\0'; // Force null termination
 
   uint16_t totalLen = sizeof(FrameHeader) + header->length;
   ProtocolUtils::appendCRC(logBuffer, totalLen);


### PR DESCRIPTION
This PR refactors the core shuttle firmware `Cntrl_V1_2_WS.ino` to implement the V2 communication protocol defined in `ShuttleProtocol.h`.

Key changes include:
- **UART Routing Optimization:** High-bandwidth telemetry (`sendTelemetryPacket`, `sendSensorPacket`, `sendStatsPacket`) and logging are now routed to `Serial1` (Display, 230400 baud) instead of the 9600 baud Radio link (`Serial2`), preventing bandwidth saturation.
- **Protocol Alignment:** Updated sync bytes to V2 constants. Replaced floating-point transmissions with scaled integers (mV for voltage, decicelsius for temperature) to improve stability and cross-platform compatibility. Removed the deprecated `timestamp` field.
- **Command Handling Overhaul:** Replaced legacy `MSG_COMMAND` logic with granular V2 command handlers (`MSG_CMD_SIMPLE`, `MSG_CMD_WITH_ARG`, `MSG_SET_DATETIME`) in `processPacket`.
- **Legacy Code Removal:** Completely rewrote `send_Cmd` to eliminate heavy `String` concatenations and switch-case logic, replacing it with efficient binary telemetry packets.
- **Security & Safety:** Implemented `sendLog` with strict bounds checking (`MAX_LOG_STRING_LEN`), forced null termination, and CRC appending to prevent buffer overflows.
- **Parser Fix:** Corrected the association of `ProtocolParser` instances: `Serial1` now feeds `parserDisplay` and `Serial2` feeds `parserRadio`.

---
*PR created automatically by Jules for task [3312940806417996112](https://jules.google.com/task/3312940806417996112) started by @Driadix*