### PR TITLE
Fix UART Buffer Blocking and Protocol FSM Sync Vulnerability

### DIFF
--- a/Cntrl_V1_2_WS.ino
+++ b/Cntrl_V1_2_WS.ino
@@ -663,16 +663,22 @@ void SystemYield() {
   static uint32_t timerUptime = 0;
 
   if (currentMillis - timerTelemetry >= 300) {
-    timerTelemetry = currentMillis;
-    sendTelemetryPacket(&Serial1);
+    if (Serial1.availableForWrite() >= sizeof(TelemetryPacket) + sizeof(FrameHeader) + 2) {
+      timerTelemetry = currentMillis;
+      sendTelemetryPacket(&Serial1);
+    }
   }
   if (currentMillis - timerSensors >= 500) {
-    timerSensors = currentMillis;
-    sendSensorPacket(&Serial1);
+    if (Serial1.availableForWrite() >= sizeof(SensorPacket) + sizeof(FrameHeader) + 2) {
+      timerSensors = currentMillis;
+      sendSensorPacket(&Serial1);
+    }
   }
   if (currentMillis - timerStats >= 5000) {
-    timerStats = currentMillis;
-    sendStatsPacket(&Serial1);
+    if (Serial1.availableForWrite() >= sizeof(StatsPacket) + sizeof(FrameHeader) + 2) {
+      timerStats = currentMillis;
+      sendStatsPacket(&Serial1);
+    }
   }
   if (currentMillis - timerUptime >= 60000) {
       timerUptime = currentMillis;
@@ -1308,11 +1314,12 @@ uint8_t processPacket(FrameHeader* header, uint8_t* payload, Stream* replyPort) 
 }
 
 uint8_t pollSerial(Stream& port, ProtocolParser& parser) {
-    while (port.available()) {
-        FrameHeader* header = parser.feed(port.read(), millis());
-        if (header) {
+    uint32_t now = millis();
+    while (port.available() > 0) {
+        FrameHeader* header = parser.feed(port.read(), now);
+        if (header != nullptr) {
             uint8_t res = processPacket(header, (uint8_t*)header + sizeof(FrameHeader), &port);
-            if (res != NO_NEW_CMD) return res;
+            return res;
         }
     }
     return NO_NEW_CMD;

--- a/ShuttleProtocol.h
+++ b/ShuttleProtocol.h
@@ -268,6 +268,8 @@ public:
                     rxBuffer[1] = byte;
                     rxIndex = 2;
                     state = STATE_READ_HEADER;
+                } else if (byte == PROTOCOL_SYNC_1_V2) {
+                    state = STATE_WAIT_SYNC2;
                 } else {
                     state = STATE_WAIT_SYNC1;
                 }


### PR DESCRIPTION
This PR implements the three core bug fixes and architectural improvements required for serial communications to function reliably over high-speed telemetry outputs and noisy radio channels:

1. **TX Buffer Saturation (The Silent Blocker):** Wrapped the periodic telemetry pushes inside `SystemYield()` with `if (Serial1.availableForWrite() >= ...)` bounds checks. This ensures that massive structs no longer overflow the tiny MCU hardware TX FIFO, which previously caused the main execution loop (and therefore time-sensitive motor controls) to block unpredictably.
2. **The `pollSerial` Implementation (The Missing Link):** Rewrote the `while (port.available() > 0)` loop in `pollSerial` to return immediately to the main logic loop upon successful packet completion, instead of greedily waiting or attempting to process successive packets out of sync with physical motor demands. Time-checking was also shifted outside the loop to reduce instruction cycles.
3. **The Sync Trap (A Subtle Bug in Your FSM):** Modified `ShuttleProtocol.h` `ProtocolParser` by handling repeating `PROTOCOL_SYNC_1_V2` (0xBB) bytes gracefully. The `STATE_WAIT_SYNC2` state machine case now maintains its state instead of blindly dropping back to `STATE_WAIT_SYNC1` if consecutive initial sync bytes appear due to radio noise, preventing the arbitrary dropping of valid packets.

All changes are carefully non-blocking and ensure core lifter and motor control logic behavior was unaltered.

---
*PR created automatically by Jules for task [4935518555856244256](https://jules.google.com/task/4935518555856244256) started by @Driadix*